### PR TITLE
feat: event watcher now wait until the event is confirmed for X blocks

### DIFF
--- a/src/event_watcher_http.rs
+++ b/src/event_watcher_http.rs
@@ -1,8 +1,11 @@
 use std::str::FromStr;
 use std::time;
 use web3::{
+    api::Eth,
+    confirm,
     futures::{self, StreamExt},
-    types::{BlockNumber, FilterBuilder, Log, H160, H256},
+    types::{BlockNumber, Filter, FilterBuilder, Log, H160, H256, U64},
+    Transport,
 };
 
 #[tokio::main]
@@ -11,6 +14,59 @@ async fn main() -> web3::contract::Result<()> {
         "https://bsc-dataseed.binance.org/",
     )?);
 
+    // to be input
+    //
+    let start_contract_block = BlockNumber::Earliest;
+    let confirmations = 15;
+    let poll_interval = time::Duration::from_millis(1000);
+    //
+    //
+
+    let logs_stream = web3
+        .eth_filter()
+        .create_logs_filter(filter(start_contract_block))
+        .await?
+        .stream(poll_interval);
+    futures::pin_mut!(logs_stream);
+
+    while let Some(result_log) = logs_stream.next().await {
+        let log: Log = match result_log {
+            Ok(log) => log,
+            Err(e) => {
+                println!("{}", e);
+                continue;
+            }
+        };
+
+        let log_hash = match log.block_hash {
+            Some(log_hash) => log_hash,
+            None => {
+                println!("how could a log have no hash ???");
+                continue;
+            }
+        };
+
+        let eth = web3.eth();
+        confirm::wait_for_confirmations(
+            web3.eth(),
+            web3.eth_filter(),
+            poll_interval,
+            confirmations,
+            || transaction_receipt_block_number_check(&eth, log_hash),
+        )
+        .await?;
+
+        println!("----------------------------------------");
+        println!("Block Number: {}", log.block_number.unwrap());
+        println!("Event Address: {:?}", log.topics[0]);
+        println!("From Address: {}", log.topics[1]);
+        println!("To Address: {}", log.topics[2]);
+        println!("Data: {}", format!("0x{}", hex::encode(log.data.0)));
+    }
+    Ok(())
+}
+
+fn filter(start_at: BlockNumber) -> Filter {
     let contract_address: H160 =
         H160::from_str("0x0eD7e52944161450477ee417DE9Cd3a859b14fD0").unwrap();
 
@@ -22,7 +78,7 @@ async fn main() -> web3::contract::Result<()> {
         H256::from_str("0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef")
             .unwrap();
 
-    let filter = FilterBuilder::default()
+    FilterBuilder::default()
         .address(vec![contract_address])
         .topics(
             Some(vec![signature_event_swap, signature_event_transfer]),
@@ -30,23 +86,15 @@ async fn main() -> web3::contract::Result<()> {
             None,
             None,
         )
-        .from_block(BlockNumber::Earliest)
+        .from_block(start_at)
         .to_block(BlockNumber::Latest)
-        .build();
+        .build()
+}
 
-    let filter = web3.eth_filter().create_logs_filter(filter).await?;
-
-    let logs_stream = filter.stream(time::Duration::from_millis(100));
-    futures::pin_mut!(logs_stream);
-
-    while let Some(result_log) = logs_stream.next().await {
-        let log: Log = result_log.unwrap();
-        println!("----------------------------------------");
-        println!("Block Number: {}", log.block_number.unwrap());
-        println!("Event Address: {:?}", log.topics[0]);
-        println!("From Address: {}", log.topics[1]);
-        println!("To Address: {}", log.topics[2]);
-        println!("Data: {}", format!("0x{}", hex::encode(log.data.0)));
-    }
-    Ok(())
+async fn transaction_receipt_block_number_check<T: Transport>(
+    eth: &Eth<T>,
+    hash: H256,
+) -> web3::error::Result<Option<U64>> {
+    let receipt = eth.transaction_receipt(hash).await?;
+    Ok(receipt.and_then(|receipt| receipt.block_number))
 }


### PR DESCRIPTION
This should solve the chain reorg problem by waiting til the latest event is finalized.

Supposed that the stream works by fetching from earliest event to latest event, this should works.